### PR TITLE
Allow using ArrayBuffer as epub URL

### DIFF
--- a/src/EpubView/EpubView.js
+++ b/src/EpubView/EpubView.js
@@ -18,7 +18,9 @@ class EpubView extends PureComponent {
 
   componentDidMount () {
     const {url, tocChanged} = this.props
-    this.book = new Epub(url)
+    // use empty options to avoid ArrayBuffer urls being treated as options in epub.js
+    const epubOptions = {}
+    this.book = new Epub(url, epubOptions)
     this.book.loaded.navigation.then(({toc}) => {
       this.setState({
         isLoaded: true,
@@ -109,7 +111,10 @@ EpubView.defaultProps = {
 }
 
 EpubView.propTypes = {
-  url: PropTypes.string,
+  url: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.instanceOf(ArrayBuffer)
+  ])
   loadingView: PropTypes.element,
   location: PropTypes.oneOfType([
     PropTypes.string,

--- a/src/ReactReader/ReactReader.js
+++ b/src/ReactReader/ReactReader.js
@@ -130,7 +130,10 @@ ReactReader.defaultProps = {
 ReactReader.propTypes = {
   title: PropTypes.string,
   loadingView: PropTypes.element,
-  url: PropTypes.string,
+  url: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.instanceOf(ArrayBuffer)
+  ]),
   showToc: PropTypes.bool,
   location: PropTypes.oneOfType([
     PropTypes.string,


### PR DESCRIPTION
Epub.js allows using ArrayBuffer as epub URL https://github.com/gerhardsletten/epub.js/blob/v0.3-react-reader/src/epub.js#L9

```javascript
/**
 * Creates a new Book
 * @param {string|ArrayBuffer} url URL, Path or ArrayBuffer
 * @param {object} options to pass to the book
 * @returns {Book} a new Book object
 * @example ePub("/path/to/book.epub", {})
 */
function ePub(url, options) {
	return new Book(url, options);
}
```

Since `react-reader` is a wrapper around Epub.js I think it would be nice to have this option available. In fact I have added and tested these changes in our project where epub files are fetched from URL without .epub extension. 

Such URLs are determined as a directory here [book.js#L346](https://github.com/gerhardsletten/epub.js/blob/v0.3-react-reader/src/book.js#L346), which results in an unexpected behavior. Fortunately if URL is not a string then its type is correctly determined as binary and epub is rendered as expected. However in order to make this work `ePub` (and in return `Book`) objects have to be constructed with explicit options. Otherwise `ArrayBuffer` URL is mistaken for options.

```javascript
// Allow passing just options to the Book
if (typeof(options) === "undefined"
	&& typeof(url) === "object") {
	options = url;
	url = undefined;
}
```