### PR TITLE
Removed epubInitOptions punning in EpubView

### DIFF
--- a/src/modules/EpubView/EpubView.js
+++ b/src/modules/EpubView/EpubView.js
@@ -27,7 +27,7 @@ class EpubView extends Component {
     if (this.book) {
       this.book.destroy();
     }
-    this.book = new Epub(url, { epubInitOptions });
+    this.book = new Epub(url, epubInitOptions);
     this.book.loaded.navigation.then(({ toc }) => {
       this.setState(
         {


### PR DESCRIPTION
When EpubView epubInitOptions are set, they are forwarded to epub.js but all the options are under the key "epubInitOptions". That parameter should just be passed through, not punned.