### PR TITLE
Left right arrow key to change pages fix. Added rendition keyup listener, changed document keydown to keyup to match

### DIFF
--- a/src/modules/EpubView/EpubView.js
+++ b/src/modules/EpubView/EpubView.js
@@ -19,7 +19,7 @@ class EpubView extends Component {
 
   componentDidMount() {
     this.initBook(true);
-    document.addEventListener("keydown", this.handleKeyPress, false);
+    document.addEventListener("keyup", this.handleKeyPress, false);
   }
 
   initBook(first) {
@@ -44,7 +44,7 @@ class EpubView extends Component {
 
   componentWillUnmount() {
     this.book = this.rendition = this.prevPage = this.nextPage = null;
-    document.removeEventListener("keydown", this.handleKeyPress, false);
+    document.removeEventListener("keyup", this.handleKeyPress, false);
   }
 
   shouldComponentUpdate(nextProps) {
@@ -90,6 +90,7 @@ class EpubView extends Component {
       this.rendition.next();
     };
     this.rendition.on("locationChanged", this.onLocationChange);
+    this.rendition.on("keyup", this.handleKeyPress);
     getRendition && getRendition(this.rendition);
   }
 


### PR DESCRIPTION
When focus is inside the epub.js iframe the document keydown listener doesn't fire. Epub.js's rendition has a keyup listener that does fire when focus is inside the iframe, and only when focus is in the iframe, so this PR adds the handleKeyPress listener to the rendition. Also changed the document keydown listeners to keyup to match (rendition doesn't fire keydown events).