### PR TITLE
Fix rendition display on empty table of contents

### DIFF
--- a/src/modules/EpubView/EpubView.js
+++ b/src/modules/EpubView/EpubView.js
@@ -86,11 +86,14 @@ class EpubView extends Component {
     };
     this.registerEvents();
     getRendition && getRendition(this.rendition);
-    this.rendition.display(
-      typeof location === "string" || typeof location === "number"
-        ? location
-        : toc[0].href
-    );
+
+    if(typeof location === "string" || typeof location === "number") {
+      this.rendition.display(location);
+    } else if(toc.length > 0 && toc[0].href) {
+      this.rendition.display(toc[0].href);
+    } else {
+      this.rendition.display();
+    }
   }
 
   registerEvents() {


### PR DESCRIPTION
Hello. I'm getting an error when opening a file with empty table of contents:
<details>
  <summary>Error</summary>
  <img src="https://user-images.githubusercontent.com/51774833/99566035-7311f500-29dd-11eb-8444-6e5029199b68.png"/>
</details>

It can be fixed it by adding table of contents length check.
Thanks a lot for this project.