### PR TITLE
Add prop `styles` to EpubView component when ReactReader is rendered

### DIFF
--- a/src/modules/ReactReader/ReactReader.js
+++ b/src/modules/ReactReader/ReactReader.js
@@ -152,6 +152,7 @@ class ReactReader extends PureComponent {
               <EpubView
                 ref={this.readerRef}
                 loadingView={loadingView}
+                styles={styles}
                 {...props}
                 tocChanged={this.onTocChange}
                 locationChanged={locationChanged}


### PR DESCRIPTION
* This prop is necessary to be able to override the style of EpubView


Example:

```javascript
import { ReactReader, ReactReaderStyle, EpubViewStyle } from 'react-reader'

const styles = {
  ...ReactReaderStyle,
  ...EpubViewStyle,
  view: {
    height: '50%',
    width: '50%'
  }
}

export default function MyComponent() {
  return (
    <div style={{ height: '100vh' }}>
      <ReactReader
        url={epubFile}
        location={location}
        locationChanged={onLocationChanged}
        getRendition={setRendition}
        tocChanged={setChapters}
        showToc={false}
        styles={styles}
      />
    </div>
  )
}
```