### PR TITLE
fix: support move pages on StrictMode

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,11 @@
-import React from 'react'
+import React, { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import App from './App'
 
 const container = document.getElementById('root')
 const root = createRoot(container)
-root.render(<App />)
+root.render(
+  <StrictMode>
+    <App />
+  </StrictMode>
+)

--- a/src/modules/EpubView/EpubView.js
+++ b/src/modules/EpubView/EpubView.js
@@ -44,6 +44,9 @@ class EpubView extends Component {
   }
 
   componentWillUnmount() {
+    if (this.book) {
+      this.book.destroy()
+    }
     this.book = this.rendition = this.prevPage = this.nextPage = null
     document.removeEventListener('keyup', this.handleKeyPress, false)
   }


### PR DESCRIPTION
Call `book.destroy()` when componentWillUnmount

https://user-images.githubusercontent.com/19714/189505971-d02f7f52-2b5e-47f8-9ef7-fdb04c67102c.mp4

React 18 + Strict Mode does mount → unmount → mount in develop mode.

> With Strict Mode starting in React 18, whenever a component mounts in development, React will simulate immediately unmounting and remounting the component:
> [Strict Mode – React](https://reactjs.org/docs/strict-mode.html#ensuring-reusable-state)

EpubView should call `book.destroy()` on `componentWillUnmount`.

fix #116 