### PR TITLE
Update EpubView on URL change

### DIFF
--- a/src/modules/EpubView/EpubView.js
+++ b/src/modules/EpubView/EpubView.js
@@ -55,7 +55,7 @@ class EpubView extends Component {
     return (
       !this.state.isLoaded ||
       nextProps.location !== this.props.location ||
-      nextProps.location !== this.props.location
+      nextProps.url !== this.props.url
     )
   }
 


### PR DESCRIPTION
I was having an issue where `EpubView` wasn't refreshing when a new URL was passed, and I think I found a bug in `shouldComponentUpdate`.

https://github.com/gerhardsletten/react-reader/blob/ab051bc1d191725b2836015750290d53828595dd/src/modules/EpubView/EpubView.js#L54-L60

It's comparing the same `location` prop twice, but I believe it was meant to compare the URL.

```ts
nextProps.url !== this.props.url
```

With this change, the component re-renders as expected when a new URL is passed.