### PR TITLE
Update minimal example code in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,13 +23,13 @@ import React, { useState } from 'react'
 import { ReactReader } from 'react-reader'
 
 export const App = () => {
-  const [location, setLocation] = useState<string | number>(0)
+  const [location, setLocation] = useState<string | number | null>(null)
   return (
     <div style={{ height: '100vh' }}>
       <ReactReader
         url="https://react-reader.metabits.no/files/alice.epub"
-        location={(epubcifi: string) => setLocation(epubcifi)}
-        locationChanged={locationChanged}
+        location={location}
+        locationChanged={(epubcfi: string) => setLocation(epubcfi)}
       />
     </div>
   )


### PR DESCRIPTION
Loving this lib. But got tripped up by the minimal example. Proposing 3 changes:

1. Props used were incorrect.
2. Changed typo in arg `epubcifi`. Should be `epubcfi` (CFI is canonical fragment identifier, today I learned something new 🎉).
3. Changed the default state from 0 to null because I had issues with several books where it would render at the cover page but I could not navigate from it until I used the TOC, but as soon as I changed the `0` to `1` or `null` it would work, because it would start off after the cover page.

Some extra notes on point 3:
I got this error with the default "https://react-reader.metabits.no/files/alice.epub", and I tested with other books too, mostly from https://www.epubbooks.com/. I'm wondering if I'm the only one who had that issue, I could not find any issues or discussion about this here. 
I tried validating the epubs using https://www.epubvalidation.com and got this error: Non-linear content must be reachable, but found no hyperlink to "OEBPS/cover.xhtml"
I'm using this in a capacitor app, latest react-reader version, same issue on all platforms.
Maybe point 3 is more contentious and could require some discussion, so we could leave it out of the PR and just do 1 and 2, and open an issue for 3? Any thoughts?