### PR TITLE
feat: request error handling in EpubView

### DIFF
--- a/lib/ReactReader/ReactReader.tsx
+++ b/lib/ReactReader/ReactReader.tsx
@@ -323,6 +323,7 @@ export class ReactReader extends PureComponent<
       title,
       showToc = true,
       loadingView,
+      errorView,
       readerStyles = defaultStyles,
       locationChanged,
       swipeable,
@@ -370,6 +371,13 @@ export class ReactReader extends PureComponent<
                     <div style={readerStyles.loadingView}>Loading…</div>
                   ) : (
                     loadingView
+                  )
+                }
+                errorView={
+                  errorView === undefined ? (
+                    <div style={readerStyles.errorView}>Error loading book</div>
+                  ) : (
+                    errorView
                   )
                 }
                 epubViewStyles={epubViewStyles}

--- a/lib/ReactReader/style.ts
+++ b/lib/ReactReader/style.ts
@@ -20,6 +20,7 @@ export interface IReactReaderStyle {
   tocButtonBar: CSSProperties
   tocButtonBarTop: CSSProperties
   loadingView: CSSProperties
+  errorView: CSSProperties
   tocButtonBottom: CSSProperties
 }
 
@@ -163,6 +164,15 @@ export const ReactReaderStyle: IReactReaderStyle = {
     left: '10%',
     right: '10%',
     color: '#ccc',
+    textAlign: 'center',
+    marginTop: '-.5em',
+  },
+  errorView: {
+    position: 'absolute',
+    top: '50%',
+    left: '10%',
+    right: '10%',
+    color: '#c00',
     textAlign: 'center',
     marginTop: '-.5em',
   },


### PR DESCRIPTION
When loading fails, the reader just keeps displaying the loading screen. This adds an error view in case the request fails.

This does not handle invalid or corrupted files.

Maybe this could have been solved by using the `initOptions.requestMethod`, but I think it's nice to have at least a little default error handling.